### PR TITLE
Fix Linux build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ target_compile_definitions(CryptSynthPlugin
         JUCE_VST3_CAN_REPLACE_VST2=0)
 
 juce_add_binary_data(CryptSynthPluginData SOURCES ui.png)
-
+set_target_properties(CryptSynthPluginData PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 target_link_libraries(CryptSynthPlugin PRIVATE
         CryptSynthPluginData


### PR DESCRIPTION
Hi,

CMake builds static libraries without `-fPIC` by default for some reason, so you would get linking errors when JUCE tries to link the binary data target. You need to manually add this property to the target because for some reason JUCE doesn't do it for you.