### PR TITLE
Improve Linux build instructions and fix release build segfault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+build/
 cmake-build-debug
 cmake-build-release
 release-scripts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,11 @@ target_compile_definitions(CryptSynthPlugin
         PUBLIC
         JUCE_WEB_BROWSER=0
         JUCE_USE_CURL=0
-        JUCE_VST3_CAN_REPLACE_VST2=0)
+        JUCE_VST3_CAN_REPLACE_VST2=0
+
+        # We don't have to display the splash screen since we're using JUCE
+        # under the GPL
+        JUCE_DISPLAY_SPLASH_SCREEN=0)
 
 juce_add_binary_data(CryptSynthPluginData SOURCES ui.png)
 set_target_properties(CryptSynthPluginData PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/CryptPlugin.cpp
+++ b/CryptPlugin.cpp
@@ -411,7 +411,9 @@ public:
     /** Set up the editor */
     explicit CryptEditor(CryptAudioProcessor &processor):
             AudioProcessorEditor(processor),
-            processor(processor) {
+            processor(processor),
+            vitlink("Vitling", URL("https://www.vitling.xyz")),
+            bclink("Bow Church", URL("https://bowchurch.bandcamp.com")) {
 
         LookAndFeel &lookAndFeel = getLookAndFeel();
 
@@ -433,11 +435,7 @@ public:
         createControlFor("unison", Slider::LinearBar, 100,350,100,30);
         createControlFor("master", Slider::LinearBar, 400,350,100,30, "dB");
 
-        vitlink.setURL(URL("https://www.vitling.xyz"));
-        vitlink.setButtonText("Vitling");
         vitlink.setBounds(300,10,100,20);
-        bclink.setURL(URL("https://bowchurch.bandcamp.com"));
-        bclink.setButtonText("Bow Church");
         bclink.setBounds(400,10,100,20);
 
         addAndMakeVisible(vitlink);

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ These are Debian/Ubuntu package names (install with `sudo apt-get install ` and 
 
 ```bash
 git clone --recursive --shallow-submodules https://github.com/DavW/crypt.git
-cmake -S crypt -B crypt-build
-cmake --build crypt-build --config Release --verbose
+cd crypt
+cmake -Bbuild -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
 ```
 
 ## Support


### PR DESCRIPTION
The instructions wouldn't actually build a release build, since neither Ninja nor the Make based generators use the build profiles, and having a build directory inside of the repo is the canonical way to build CMake projects. There is one other issue though (which is why I marked this as a draft), and that's that release builds segfault under Linux. I haven't looked into this myself yet, but this is a backtrace:

```
Thread 1 "carla-bridge-na" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff65017c0 (LWP 123505)]
0x00007ffff4dad318 in juce::HyperlinkButton::setURL(juce::URL const&) () from /home/robbert/.vst3/Crypt.vst3/Contents/x86_64-linux/Crypt.so
>>> bt
#0  0x00007ffff4dad318 in juce::HyperlinkButton::setURL(juce::URL const&) () at /home/robbert/.vst3/Crypt.vst3/Contents/x86_64-linux/Crypt.so
#1  0x00007ffff4d5cfef in CryptEditor::CryptEditor(CryptAudioProcessor&) () at /home/robbert/.vst3/Crypt.vst3/Contents/x86_64-linux/Crypt.so
#2  0x00007ffff4d557e2 in CryptAudioProcessor::createEditor() () at /home/robbert/.vst3/Crypt.vst3/Contents/x86_64-linux/Crypt.so
#3  0x00007ffff4d653ec in juce::AudioProcessor::createEditorIfNeeded() () at /home/robbert/.vst3/Crypt.vst3/Contents/x86_64-linux/Crypt.so
#4  0x00007ffff4d49e9d in non-virtual thunk to juce::JuceVST3EditController::createView(char const*) () at /home/robbert/.vst3/Crypt.vst3/Contents/x86_64-linux/Crypt.so
#5  0x00005555556e546c in  ()
#6  0x000055555566bb54 in  ()
#7  0x00005555555a90e1 in  ()
#8  0x000055555559c62f in  ()
#9  0x00007ffff7640b25 in __libc_start_main () at /usr/lib/libc.so.6
#10 0x00005555555a137e in  ()
```